### PR TITLE
Fix dependency conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,12 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.11"
+python = ">=3.8,<3.11"
 
 lava-nc = { git = "https://github.com/lava-nc/lava.git", branch = "main", develop = true }
 
 numpy = "^1.23.0"
-scipy = "^1.11.0"
+scipy = "^1.10.0"
 h5py = "^3.8.0"
 numba = "^0.57.0"
 opencv-python = "^4.5.5.64"


### PR DESCRIPTION
Python and Spicy version requirements are different from other Lava libraries.
This PR is to fix the version conflict.